### PR TITLE
Texts made visible properly

### DIFF
--- a/components/faq.tsx
+++ b/components/faq.tsx
@@ -12,9 +12,9 @@ function FaqContainer({ title, text }: FaqContainerType) {
 export default function Faq() {
   return (
     <div>
-      <div className="bg-black py-14 px-44">
+      <div className="bg-black py-14 px-44 text-white my-8">
         <h1
-          className="text-4xl font-black"
+          className="text-6xl font-black"
           style={{ maxWidth: "550px" }}
         >
           FAQ

--- a/components/whats-about.tsx
+++ b/components/whats-about.tsx
@@ -45,9 +45,9 @@ function Card({ title, img, description }: WhatIsItAboutType) {
 
 export default function WhatIsItAbout() {
   return (
-    <div className="bg-black py-14 md:px-44 flex flex-col text-center justify-center items-center">
+    <div className="text-white bg-black py-14 md:px-44 flex flex-col text-center justify-center items-center">
       <h1
-        className="text-4xl md:text-6xl font-black border-b-8 pb-6 mb-12 border-b-purple-100"
+        className=" text-4xl md:text-6xl font-black border-b-8 pb-6 mb-12 border-b-purple-100"
         style={{ maxWidth: "550px" }}
       >
         What&apos;s it all about?


### PR DESCRIPTION
close #62 
Font color changed according to Figma, now texts are clearly visible
In the What's all about and FAQ section

Before 
![image](https://user-images.githubusercontent.com/83518670/196534162-2c9a4541-2f02-42a2-997e-fe86cf806deb.png)

After 
![image](https://user-images.githubusercontent.com/83518670/196534238-0ea65420-b739-4770-9065-7993341e2836.png)
